### PR TITLE
Add parameter for custom fourth spin icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ xdg-open index.html        # Linux
 - `fontSub` – font family for the secondary line
 - `fontDate` – font family for the date line
 - `fontFrom` – font family for the closing signature
+- `finalIcon` – icon to display on the fourth spin. Allowed values:
+  `ringflower.png`, `teambride.png`, `girls.png`
 
 Font parameters expect Google Fonts family names just like `font`, using `+` instead of spaces.
 
@@ -79,5 +81,6 @@ a `slot-spin-down` animation. After the configured duration, the class is
 removed and `createSingleIcon()` displays the final symbol for that reel.
 
 During the first three spins the grid stops on random, nonmatching symbols. On
-the fourth spin all reels are forced to stop on the blue bottle icon and
+the fourth spin all reels are forced to stop on the icon specified by the
+`finalIcon` parameter (default is the blue bottle). After that,
 `showReveal()` is triggered, revealing the personalized message overlay.

--- a/index.html
+++ b/index.html
@@ -483,6 +483,14 @@
           "instructionsOverlay",
         );
         const params = getParams();
+        const finalIconMap = {
+          "ringflower": "img/ringflower.png",
+          "ringflower.png": "img/ringflower.png",
+          "teambride": "img/teambride.png",
+          "teambride.png": "img/teambride.png",
+          "girls": "img/girls.png",
+          "girls.png": "img/girls.png",
+        };
         const safeTextColor = sanitizeColor(params.textcolor, "#ffffff");
         const safeOutlineColor = sanitizeColor(params.outlinecolor, "#7e5e4f");
 
@@ -653,14 +661,15 @@
           const spinDuration = 900;
           const delayStep = 600;
           if (spinCount === 4) {
-            const babyBottle = icons[5];
+            const finalIcon =
+              finalIconMap[(params.finalicon || "").toLowerCase()] || icons[5];
             reels.forEach((reel, i) => {
               const delay = i * delayStep;
               const callback =
                 i === reels.length - 1 ? () => setTimeout(showReveal, 500) : null;
-              spinReel(reel, delay, spinDuration, babyBottle, callback);
+              spinReel(reel, delay, spinDuration, finalIcon, callback);
             });
-            currentSymbols = reels.map(() => babyBottle);
+            currentSymbols = reels.map(() => finalIcon);
           } else {
             generateRandomNonMatchingSymbols();
             reels.forEach((reel, i) => {


### PR DESCRIPTION
## Summary
- add `finalIcon` URL parameter
- show the final icon from `finalIcon` on the fourth spin
- document `finalIcon` and update description of fourth spin behavior

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_688d08937908832f8e5b9d49831efa23