### PR TITLE
Fix textFit crash that halted reel spin

### DIFF
--- a/index.html
+++ b/index.html
@@ -737,8 +737,8 @@ const finalIcon =
         }
 
         function fitRevealLine(el, type) {
-          if (type === "photo") return;
-          textFit(el, {
+          if (type === "photo" || typeof window.textFit !== "function") return;
+          window.textFit(el, {
             alignVert: true,
             alignHoriz: true,
             multiLine: true,


### PR DESCRIPTION
## Summary
- prevent errors when the TextFit script fails to load by checking if `window.textFit` exists before calling it

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688d1bd87acc832f9cd1d6f17b3dfc8d