### PR TITLE
Allow replay after reveal

### DIFF
--- a/index.html
+++ b/index.html
@@ -822,6 +822,8 @@ const finalIcon =
             setTimeout(() => {
               revealOverlay.style.opacity = "0";
               revealOverlay.style.pointerEvents = "none";
+              // Reset count so a full cycle can play again
+              spinCount = 0;
             }, hideDelay);
           }
 


### PR DESCRIPTION
## Summary
- reset `spinCount` after the reveal overlay hides

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688d298666f0832f8a5ced0a01595895