### PR TITLE
Add staggered reel spins with final reveal icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,6 @@ transition. After the configured duration the strip resets back to the start and
 During the first three spins the grid stops on random, nonmatching symbols. On
 the fourth spin all reels are forced to stop on the icon specified by the
 `finalIcon` parameter (default is the blue bottle). After that,
-`showReveal()` is triggered, revealing the personalized message overlay.
+`showReveal()` is triggered, revealing the personalized message overlay. Any
+spins after the reveal return to being completely random, so matches may occur
+naturally.

--- a/index.html
+++ b/index.html
@@ -89,7 +89,11 @@
         transform: translateY(0);
         will-change: transform;
       }
-      @keyframes reel-spin {
+      .reel-track.spinning {
+        animation: slot-spin-down var(--duration)
+          cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
+      }
+      @keyframes slot-spin-down {
         to {
           transform: translateY(var(--final-offset));
         }
@@ -416,6 +420,10 @@
           "img/paw.png",
         ];
 
+        function getRandomIcon() {
+          return icons[Math.floor(Math.random() * icons.length)];
+        }
+
         function preloadImages(paths) {
           return Promise.all(
             paths.map((src) => {
@@ -438,16 +446,16 @@
           "img/directions.png",
         ]);
 
-        function buildReelTrack() {
+        function createSingleIcon(reel, src) {
           const track = document.createElement("div");
           track.className = "reel-track";
-          [...icons, "img/ringflower.png"].forEach((src) => {
-            const img = document.createElement("img");
-            img.src = src;
-            img.alt = "Slot Icon";
-            track.appendChild(img);
-          });
-          return track;
+          const img = document.createElement("img");
+          img.src = src;
+          img.alt = "Slot Icon";
+          track.appendChild(img);
+          const existing = reel.querySelector(".reel-track");
+          if (existing) existing.replaceWith(track);
+          else reel.appendChild(track);
         }
 
         const slotMachine = document.getElementById("slotMachine");
@@ -455,10 +463,7 @@
         const reels = [];
         for (let i = 1; i <= 3; i++) {
           const reel = document.getElementById(`reel${i}`);
-          const track = buildReelTrack();
-          const existing = reel.querySelector(".reel-track");
-          if (existing) existing.replaceWith(track);
-          else reel.appendChild(track);
+          createSingleIcon(reel, getRandomIcon());
           reels.push(reel);
         }
         const introOverlay = document.getElementById("introOverlay");
@@ -471,6 +476,20 @@
           "instructionsOverlay",
         );
         const params = getParams();
+        const finalIconName = (params.finalicon || "").toLowerCase();
+        const allowedFinalIcons = [
+          "ringflower.png",
+          "teambride.png",
+          "girls.png",
+          "champagne.png",
+        ];
+        const finalIconSrc = `img/${
+          allowedFinalIcons.includes(finalIconName)
+            ? finalIconName
+            : "champagne.png"
+        }`;
+        let spinCount = 0;
+        let revealed = false;
         const safeTextColor = sanitizeColor(params.textcolor, "#ffffff");
         const safeOutlineColor = sanitizeColor(params.outlinecolor, "#7e5e4f");
 
@@ -639,29 +658,65 @@
           spinButton.style.pointerEvents = "none";
           const spinDuration = 1200;
           const delayStep = 300;
+          spinCount++;
+          const isRevealSpin = !revealed && spinCount === 4;
+          const finalIcons = [];
+          if (isRevealSpin) {
+            for (let i = 0; i < reels.length; i++) finalIcons[i] = finalIconSrc;
+          } else {
+            for (let i = 0; i < reels.length; i++) {
+              finalIcons[i] = getRandomIcon();
+            }
+            if (!revealed && spinCount <= 3) {
+              while (
+                finalIcons[0] === finalIcons[1] &&
+                finalIcons[1] === finalIcons[2]
+              ) {
+                for (let i = 0; i < reels.length; i++) {
+                  finalIcons[i] = getRandomIcon();
+                }
+              }
+            }
+          }
           reels.forEach((reel, i) => {
             const delay = i * delayStep;
-            const callback =
-              i === reels.length - 1 ? () => setTimeout(showReveal, 500) : null;
-            spinReel(reel, delay, spinDuration, callback);
+            spinReel(reel, delay, spinDuration, finalIcons[i]);
           });
-          const pointerDelay = delayStep * (reels.length - 1) + spinDuration + 500;
+          const totalDelay = delayStep * (reels.length - 1) + spinDuration;
           setTimeout(() => {
             spinButton.style.pointerEvents = "auto";
-          }, pointerDelay);
+            if (isRevealSpin) {
+              revealed = true;
+              showReveal();
+            }
+          }, totalDelay + 100);
         }
 
-        function spinReel(reel, delay, duration, callback) {
+        function spinReel(reel, delay, duration, finalIcon) {
           setTimeout(() => {
-            const track = reel.querySelector(".reel-track");
+            const track = document.createElement("div");
+            track.className = "reel-track spinning";
+            const iconCount = 10;
+            for (let i = 0; i < iconCount; i++) {
+              const img = document.createElement("img");
+              img.src = getRandomIcon();
+              img.alt = "Slot Icon";
+              track.appendChild(img);
+            }
+            const finalImg = document.createElement("img");
+            finalImg.src = finalIcon;
+            finalImg.alt = "Slot Icon";
+            track.appendChild(finalImg);
+            const existing = reel.querySelector(".reel-track");
+            if (existing) existing.replaceWith(track);
+            else reel.appendChild(track);
             const iconHeight = reel.offsetHeight;
             const finalOffset = -(track.children.length - 1) * iconHeight;
-            track.style.animation = "none";
-            track.style.transform = "translateY(0)";
             track.style.setProperty("--final-offset", `${finalOffset}px`);
-            void track.offsetWidth;
-            track.style.animation = `reel-spin ${duration}ms cubic-bezier(0.22, 0.61, 0.36, 1) forwards`;
-            if (callback) setTimeout(callback, duration);
+            track.style.setProperty("--duration", `${duration}ms`);
+            setTimeout(() => {
+              createSingleIcon(reel, finalIcon);
+            }, duration);
           }, delay);
         }
 


### PR DESCRIPTION
## Summary
- Animate reels using `slot-spin-down` and a new `spinning` class
- Randomize reel icons with guaranteed non-matching first spins and forced final icon on the fourth spin
- Document post-reveal behavior and controls in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688d77fa2860832f9eae8832b518d470