### PR TITLE
Use translate3d for smoother slot animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,21 +90,24 @@
         flex-direction: column;
         align-items: center;
         justify-content: flex-start;
-        transition: transform 0.35s cubic-bezier(0.22, 0.61, 0.36, 1);      }
+        transition: transform 0.35s cubic-bezier(0.22, 0.61, 0.36, 1);
+        will-change: transform;
+      }
       @keyframes slot-spin-down {
         0% {
-          transform: translateY(-20%);
+          transform: translate3d(0, -20%, 0);
         }
         100% {
-          transform: translateY(0);
+          transform: translate3d(0, 0, 0);
         }
-      }
-      .reel-strip.spinning {
-        animation: slot-spin-down 0.2s linear infinite;
       }
       .reel-strip {
         display: flex;
         flex-direction: column;
+        will-change: transform;
+      }
+      .reel-strip.spinning {
+        animation: slot-spin-down 0.25s linear infinite;
       }
       .reel-item {
         height: 100%;


### PR DESCRIPTION
## Summary
- Replace slot spin keyframes with translate3d transforms to leverage GPU acceleration
- Hint browsers with `will-change: transform` on reel elements for better performance
- Slightly increase spin animation duration for smoother effect on mobile

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_b_688d891e4df8832faf19021ba7246024