### PR TITLE
Reduce blur for mobile viewports

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,8 +67,19 @@
         z-index: 1;
         pointer-events: none;
       }
-      .blur-background {
-        filter: blur(8px);
+      @media (min-width: 601px) {
+        .blur-background,
+        .spin-button.blur-background {
+          filter: blur(8px);
+        }
+      }
+
+      @media (max-width: 600px) {
+        .blur-background,
+        .spin-button.blur-background {
+          filter: none;
+          opacity: 0.7;
+        }
       }
       .reel {
         position: absolute;
@@ -146,9 +157,6 @@
         transition:
           all 0.08s,
           filter 0.5s ease;
-      }
-        .spin-button.blur-background {
-        filter: blur(8px);
       }
       .spin-button img {
         width: 100%;


### PR DESCRIPTION
## Summary
- Add responsive media queries for `.blur-background` and related elements
- Replace heavy blur with subtle opacity on viewports 600px wide or less

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688d891f6b68832f9ba284112b5d47b0