### PR TITLE
Reuse reel strip and swap icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,11 @@ Open one of these URLs in your browser to see the customized reveal.
 The slot machine now shows a **1×3 grid** of icons. Each of the three columns is
 a reel that spins vertically. When the spin button is pressed, the
 `handleSpin()` function disables the button and calls `spinReel()` for each reel
-using small delays so they start one after another. `spinReel()` builds a
-vertical strip of random icons and animates it upward using a CSS `transform`
-transition. After the configured duration the strip resets back to the start and
-`createSingleIcon()` displays the final symbol for that reel.
+using small delays so they start one after another. Each reel is initialized
+with a reusable `.reel-strip` of placeholder icons. `spinReel()` swaps the
+images in place on that strip, toggles a `spinning` class to animate it, and
+after the configured duration updates the first image to show the final symbol
+without replacing the container.
 
 During the first three spins the grid stops on random, nonmatching symbols. On
 the fourth spin all reels are forced to stop on the icon specified by the

--- a/index.html
+++ b/index.html
@@ -470,7 +470,9 @@
         }
 
         function createSingleIcon(reel, icon) {
-          reel.innerHTML = `<div class="reel-inner"><img src="${icon}" alt="Slot Icon"></div>`;
+          const strip = reel.querySelector(".reel-strip");
+          const firstImg = strip.querySelector(".reel-item img");
+          if (firstImg) firstImg.src = icon;
         }
 
         function createReelStrip(reel) {
@@ -496,7 +498,9 @@
         const spinButton = document.getElementById("spinButton");
         const reels = [];
         for (let i = 1; i <= 3; i++) {
-          reels.push(document.getElementById(`reel${i}`));
+          const reel = document.getElementById(`reel${i}`);
+          reels.push(reel);
+          createReelStrip(reel);
         }
         const introOverlay = document.getElementById("introOverlay");
         const introLinesDiv = document.getElementById("introLines");
@@ -715,7 +719,10 @@ const finalIcon =
         }
         function spinReel(reel, delay, duration, finalIcon, callback) {
           setTimeout(() => {
-            const strip = createReelStrip(reel);
+            const strip = reel.querySelector(".reel-strip");
+            strip.querySelectorAll("img").forEach((img) => {
+              img.src = getRandomIcon();
+            });
             strip.classList.add("spinning");
             setTimeout(() => {
               strip.classList.remove("spinning");


### PR DESCRIPTION
## Summary
- Prebuild a reusable `.reel-strip` for each reel and seed it with placeholder icons
- Update `spinReel` to randomize images, toggle the `spinning` class, and update the first icon instead of rebuilding DOM
- Document the new reel behavior in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688d89306cf8832f9a18ccdd60f3a791