### PR TITLE
Show single icons before first spin

### DIFF
--- a/index.html
+++ b/index.html
@@ -484,8 +484,15 @@
         }
 
         function createSingleIcon(reel, icon) {
-          const strip = reel.querySelector(".reel-strip");
-          strip.innerHTML = "";
+          let strip = reel.querySelector(".reel-strip");
+          if (!strip) {
+            reel.innerHTML = "";
+            strip = document.createElement("div");
+            strip.className = "reel-strip";
+            reel.appendChild(strip);
+          } else {
+            strip.innerHTML = "";
+          }
           const item = document.createElement("div");
           item.className = "reel-item";
           const img = document.createElement("img");
@@ -520,7 +527,7 @@
         for (let i = 1; i <= 3; i++) {
           const reel = document.getElementById(`reel${i}`);
           reels.push(reel);
-          createReelStrip(reel);
+          createSingleIcon(reel, getRandomIcon());
         }
         const introOverlay = document.getElementById("introOverlay");
         const introLinesDiv = document.getElementById("introLines");


### PR DESCRIPTION
## Summary
- Ensure each reel shows only one symbol when the game loads
- Simplify reel setup to create icon strips only during spins

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688d9beddfc4832fba92df43493f151f