### PR TITLE
Shrink reel icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,8 +140,8 @@
         top: 38.0%;
       }
       .reel-item img {
-        width: 85%;
-        height: 85%;
+        width: 72.25%;
+        height: 72.25%;
         object-fit: contain;
         display: block;
         margin: auto;


### PR DESCRIPTION
## Summary
- reduce reel icon size by 15% so they fit better in their frames

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688d9edf22b8832f9703991c63d1034a