### PR TITLE
Reuse reel strip for smoother slot animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ The slot machine now shows a **1×3 grid** of icons. Each of the three columns i
 a reel that spins vertically. When the spin button is pressed, the
 `handleSpin()` function disables the button and calls `spinReel()` for each reel
 using small delays so they start one after another. Each reel is initialized
-with a reusable `.reel-strip` of placeholder icons. `spinReel()` swaps the
-images in place on that strip, toggles a `spinning` class to animate it, and
-after the configured duration updates the first image to show the final symbol
-without replacing the container.
+with a reusable `.reel-strip` of placeholder icons. `spinReel()` updates the
+`src` of those images in place, applies a `transform` transition to scroll
+through them, and after the transition snaps the strip back so the chosen symbol
+sits in the first slot—without rebuilding the container.
 
 During the first three spins the grid stops on random, nonmatching symbols. On
 the fourth spin all reels are forced to stop on the icon specified by the

--- a/index.html
+++ b/index.html
@@ -104,21 +104,10 @@
         transition: transform 0.35s cubic-bezier(0.22, 0.61, 0.36, 1);
         will-change: transform;
       }
-      @keyframes slot-spin-down {
-        0% {
-          transform: translate3d(0, -20%, 0);
-        }
-        100% {
-          transform: translate3d(0, 0, 0);
-        }
-      }
       .reel-strip {
         display: flex;
         flex-direction: column;
         will-change: transform;
-      }
-      .reel-strip.spinning {
-        animation: slot-spin-down 0.25s linear infinite;
       }
       .reel-item {
         flex: 0 0 100%;
@@ -483,30 +472,13 @@
           return icons[Math.floor(Math.random() * icons.length)];
         }
 
-        function createSingleIcon(reel, icon) {
-          let strip = reel.querySelector(".reel-strip");
-          if (!strip) {
-            reel.innerHTML = "";
-            strip = document.createElement("div");
-            strip.className = "reel-strip";
-            reel.appendChild(strip);
-          } else {
-            strip.innerHTML = "";
-          }
-          const item = document.createElement("div");
-          item.className = "reel-item";
-          const img = document.createElement("img");
-          img.src = icon;
-          img.alt = "Slot Icon";
-          item.appendChild(img);
-          strip.appendChild(item);
-        }
-
-        function createReelStrip(reel) {
-          reel.innerHTML = "";
+        const STRIP_SIZE = 15;
+        function initializeReel(reel) {
+          const existing = reel.querySelector(".reel-strip");
+          if (existing) return existing;
           const strip = document.createElement("div");
           strip.className = "reel-strip";
-          for (let i = 0; i < 10; i++) {
+          for (let i = 0; i < STRIP_SIZE; i++) {
             const item = document.createElement("div");
             item.className = "reel-item";
             const img = document.createElement("img");
@@ -515,6 +487,7 @@
             item.appendChild(img);
             strip.appendChild(item);
           }
+          reel.innerHTML = "";
           reel.appendChild(strip);
           return strip;
         }
@@ -527,7 +500,7 @@
         for (let i = 1; i <= 3; i++) {
           const reel = document.getElementById(`reel${i}`);
           reels.push(reel);
-          createSingleIcon(reel, getRandomIcon());
+          initializeReel(reel);
         }
         const introOverlay = document.getElementById("introOverlay");
         const introLinesDiv = document.getElementById("introLines");
@@ -712,7 +685,7 @@
         function handleSpin() {
           spinCount++;
           spinButton.style.pointerEvents = "none";
-          const spinDuration = 900;
+          const spinDuration = 1200;
           const delayStep = 600;
           if (spinCount === 4) {
 const finalIcon =
@@ -746,13 +719,28 @@ const finalIcon =
         }
         function spinReel(reel, delay, duration, finalIcon, callback) {
           setTimeout(() => {
-            const strip = createReelStrip(reel);
-            strip.classList.add("spinning");
-            setTimeout(() => {
-              strip.classList.remove("spinning");
-              createSingleIcon(reel, finalIcon || getRandomIcon());
+            const strip = initializeReel(reel);
+            const imgs = strip.querySelectorAll("img");
+            for (let i = 0; i < imgs.length - 1; i++) {
+              imgs[i].src = getRandomIcon();
+            }
+            imgs[imgs.length - 1].src = finalIcon || getRandomIcon();
+            strip.style.transition = "none";
+            strip.style.transform = "translateY(0)";
+            void strip.offsetHeight;
+            strip.style.transition = `transform ${duration}ms ease-out`;
+            strip.style.transform = `translateY(-${(imgs.length - 1) * 100}%)`;
+            function onTransitionEnd() {
+              strip.removeEventListener("transitionend", onTransitionEnd);
+              const finalSrc = imgs[imgs.length - 1].src;
+              strip.style.transition = "none";
+              strip.style.transform = "translateY(0)";
+              imgs.forEach((img, idx) => {
+                img.src = idx === 0 ? finalSrc : getRandomIcon();
+              });
               if (callback) callback();
-            }, duration);
+            }
+            strip.addEventListener("transitionend", onTransitionEnd);
           }, delay);
         }
 


### PR DESCRIPTION
## Summary
- Reuse each reel's `.reel-strip` with a fixed set of images
- Animate spins via `transform` transitions and update image `src` values in place
- Document the new transition-based approach

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688da3f240a8832fb29ebba4cc988caa