### PR TITLE
fix: size reel strip and items

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,12 +105,18 @@
         will-change: transform;
       }
       .reel-strip {
+        width: 100%;
+        height: 100%;
         display: flex;
         flex-direction: column;
+        align-items: center;
+        justify-content: flex-start;
+        transition: transform 0.35s cubic-bezier(0.22, 0.61, 0.36, 1);
         will-change: transform;
       }
       .reel-item {
         flex: 0 0 100%;
+        width: 100%;
         height: 100%;
         display: flex;
         justify-content: center;


### PR DESCRIPTION
## Summary
- give `.reel-strip` full size and alignment like the old `.reel-inner`
- ensure `.reel-item` spans the reel to keep icons visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688da9e6abc8832f865f03fbaa6bf14c