### PR TITLE
Enlarge lipstick slot icon by 20%

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,6 +147,11 @@
         transform-style: preserve-3d;
         transform-origin: 50% 50%;
       }
+      .reel-inner img[src$="lipstick.png"],
+      .reel-item img[src$="lipstick.png"] {
+        width: 86.7%;
+        height: 86.7%;
+      }
       .spin-button {
         position: absolute;
         width: 52.81%;


### PR DESCRIPTION
## Summary
- scale up lipstick image so it matches other slot icons

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68917b475618832f8b2cb8703b943102