### PR TITLE
feat: support custom reveal message

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ xdg-open index.html        # Linux
 
 `index.html` supports several query parameters so you can customize the reveal text and appearance. Parameters are optional and can be combined:
 
-- `main` – main headline (default: "We are expecting!")
+- `message` – message displayed after the reels match (default: "Will you be my bridesmaid?")
+- `main` – alias for `message` to maintain backward compatibility
 - `sub` – secondary line of text
 - `date` – additional date or detail line
 - `photo` – URL to an image shown as a circular avatar
@@ -56,6 +57,10 @@ index.html?finalIcon=girls.png
 ```
 
 ### Example links
+
+```
+index.html?message=Will%20you%20join%20the%20party%3F
+```
 
 ```
 index.html?main=We%27re%20Engaged!&sub=Save%20the%20Date&date=June%202024

--- a/index.html
+++ b/index.html
@@ -411,7 +411,8 @@
         if (photo && !/^(https?:|data:image\/)/i.test(photo)) {
           photo = "";
         }
-        const main = params.main || "We are expecting!";
+        const main =
+          params.message || params.main || "Will you be my bridesmaid?";
         const sub = params.sub || "";
         const date = params.date || "";
         const from = params.from || "";


### PR DESCRIPTION
## Summary
- allow customizing the reveal message with a `message` URL parameter
- document new parameter and provide usage example

## Testing
- `npx prettier --check index.html README.md`


------
https://chatgpt.com/codex/tasks/task_b_689184f742e4832f892d2631ef29bd91