### PR TITLE
Delay reveal until after balloon drop and blur background

### DIFF
--- a/index.html
+++ b/index.html
@@ -720,7 +720,7 @@
                 i === reels.length - 1
                   ? () => {
                       setTimeout(dropBalloons, 200);
-                      setTimeout(showReveal, 700);
+                      setTimeout(showReveal, 1200);
                     }
                   : null;
               spinReel(reel, delay, spinDuration, finalIcon, callback);
@@ -877,6 +877,9 @@
         }
         // -------- Balloon logic --------
         function dropBalloons() {
+          slotMachine.classList.add("blur-background");
+          reels.forEach((r) => r.classList.add("blur-background"));
+          spinButton.classList.add("blur-background");
           const container = document.getElementById("container");
           const images = ["img/19.png", "img/20.png", "img/21.png"];
 


### PR DESCRIPTION
## Summary
- Delay reveal message to 1 second after balloon drop
- Blur slot machine and controls when balloons appear

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68918f5162a0832f90f943d588821748