### PR TITLE
Scale overlay message to fill screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project contains a single HTML file that displays an interactive slot machine-style reveal. Spinning the reels a few times eventually triggers a personalized message overlay with a celebratory balloon drop. It's designed for fun occasions like pregnancy announcements, graduations, or other surprises.
 
+The overlay message automatically scales to fill the screen, adapting to however much text you supply.
+
 ## Opening the page
 
 You can open `index.html` directly in any modern web browser. Simply double-click the file or serve it through a local HTTP server and navigate to the page.

--- a/index.html
+++ b/index.html
@@ -191,8 +191,8 @@
         flex-direction: column;
         justify-content: center;
         align-items: center;
-        padding: 1vh;
-        gap: 1vh;
+        padding: 0;
+        gap: 0;
         box-sizing: border-box;
         z-index: 5000;
         opacity: 0;
@@ -224,8 +224,8 @@
         align-items: center;
         width: 100%;
         height: 100%;
-        gap: 2vh;
-        padding: 2vh 3vw;
+        gap: 0;
+        padding: 0;
         box-sizing: border-box;
       }
 
@@ -283,7 +283,7 @@
           border-radius: 0;
         }
         .reveal-lines {
-          padding-top: calc(2vh + env(safe-area-inset-top, 1vh));
+          padding-top: env(safe-area-inset-top, 0);
         }
       }
       /* Instructions Overlay */
@@ -793,7 +793,7 @@
             multiLine: true,
             detectMultiLine: true,
             minFontSize: 12,
-            maxFontSize: 50,
+            maxFontSize: 500,
           });
         }
 


### PR DESCRIPTION
## Summary
- remove overlay padding so message area uses full screen
- allow textFit to grow much larger so short messages expand
- note in README that overlay text scales to available space

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689190da9c2c832f818f44432b406165