### PR TITLE
feat: enlarge slot icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,8 +138,8 @@
         top: 38%;
       }
       .reel-item img {
-        width: 72.25%;
-        height: 72.25%;
+        width: 86.7%;
+        height: 86.7%;
         object-fit: contain;
         display: block;
         margin: auto;
@@ -152,8 +152,8 @@
       }
       .reel-inner img[src$="lipstick.png"],
       .reel-item img[src$="lipstick.png"] {
-        width: 86.7%;
-        height: 86.7%;
+        width: 104.04%;
+        height: 104.04%;
       }
       .spin-button {
         position: absolute;


### PR DESCRIPTION
## Summary
- enlarge reel item images by 20%
- scale up lipstick icon accordingly

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_b_68928c5029bc832fa19c2a15d1e5c708