### PR TITLE
Limit landing overlay to slot machine area

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
       }
 
       .landing-overlay {
-        position: fixed;
+        position: absolute;
         top: 0;
         left: 0;
         width: 100%;
@@ -371,10 +371,10 @@
     </style>
   </head>
   <body>
-    <div id="landingOverlay" class="landing-overlay">
-      <div id="landingMessage" class="landing-message"></div>
-    </div>
     <div class="aspect-container">
+      <div id="landingOverlay" class="landing-overlay">
+        <div id="landingMessage" class="landing-message"></div>
+      </div>
       <div class="slot-machine-container" id="container">
         <div class="slot-machine blur-background" id="slotMachine"></div>
         <div id="reel1" class="reel blur-background">


### PR DESCRIPTION
## Summary
- Constrain landing screen overlay within the slot machine container
- Use absolute positioning so overlay covers only the game area

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6892d4ea07c0832f94fe38f1f7e508d4