### PR TITLE
Ensure reveal overlay color covers the app

### DIFF
--- a/index.html
+++ b/index.html
@@ -674,9 +674,10 @@
           document.fonts.ready.then(refitAllLines),
         );
 
+        const overlayColor = getColorOverlay(params);
         // Set overlay color on reveal
-        colorOverlay.style.background = "transparent";
-        introColorOverlay.style.background = "transparent";
+        colorOverlay.style.background = overlayColor;
+        introColorOverlay.style.background = overlayColor;
 
         // Hide instructions overlay
         function hideInstructionsOverlay() {
@@ -916,7 +917,7 @@
 
           revealOverlay.style.opacity = "1";
           revealOverlay.style.pointerEvents = "auto";
-          colorOverlay.style.background = "transparent";
+          colorOverlay.style.background = overlayColor;
           refitAllLines();
           setTimeout(() => {
             revealOverlay.style.opacity = "0";


### PR DESCRIPTION
## Summary
- Use `getColorOverlay` to obtain overlay color from parameters
- Apply the overlay color to intro and reveal overlays so the tint appears above the app

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/a-big-ask/package.json')*


------
https://chatgpt.com/codex/tasks/task_b_6892d8f78c04832fab571bf29afef765