### PR TITLE
Improve landing message layout and fit options

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
         display: flex;
         justify-content: center;
         align-items: center;
+        text-align: center;
         z-index: 1000;
         cursor: pointer;
         opacity: 1;
@@ -58,6 +59,11 @@
         padding: 1rem;
         text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000,
           1px 1px 0 #000;
+        max-width: 85%;
+        width: 85%;
+        line-height: 1.3;
+        font-size: clamp(18px, 5vw, 36px);
+        white-space: normal;
       }
       .aspect-container {
         position: relative;
@@ -572,8 +578,9 @@
               multiLine: true,
               alignHoriz: true,
               alignVert: true,
-              minFontSize: 12,
-              maxFontSize: 500,
+              minFontSize: 16,
+              maxFontSize: 48,
+              widthOnly: false,
             });
           fitLanding();
           window.addEventListener("resize", fitLanding);


### PR DESCRIPTION
## Summary
- Center intro overlay text with 85% max-width, line-height 1.3, and responsive clamp font size
- Adjust landing overlay for centered text
- Use textFit with multiline and bounded font sizes for proportional scaling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6892dfe26b5c832fa7fbbb8b3cc5ed98