### PR TITLE
feat: add landing card container

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,21 +52,25 @@
         transition: opacity 0.5s ease;
       }
 
+      .landing-card {
+        background-color: #ffe3b7;
+        border: 3px solid #614f24;
+        border-radius: 12px;
+        padding: 16px 18px;
+        max-width: 85%;
+        display: inline-block;
+      }
+
       .landing-message {
         color: #fff;
         text-align: center;
         font-family: var(--font-family), sans-serif;
         line-height: 1.3;
-        background-color: #ffe3b7;
-        border: 3px solid #614f24;
-        border-radius: 12px;
-        padding: 1rem;
         text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000,
           1px 1px 0 #000;
-        max-width: 85%;
-        display: inline-block;
         font-size: clamp(18px, 5vw, 36px);
         white-space: normal;
+        width: 100%;
       }
       .aspect-container {
         position: relative;
@@ -380,7 +384,9 @@
   <body>
     <div class="aspect-container">
       <div id="landingOverlay" class="landing-overlay">
-        <div id="landingMessage" class="landing-message"></div>
+        <div class="landing-card">
+          <div id="landingMessage" class="landing-message"></div>
+        </div>
       </div>
       <div class="slot-machine-container" id="container">
         <div class="slot-machine blur-background" id="slotMachine"></div>


### PR DESCRIPTION
## Summary
- wrap landing message in a styled card with background fill and border
- move background and border styles from landing-message to landing-card and keep textFit targeting landingMessage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6892e4201394832f951ac0b5f207aa09